### PR TITLE
Added abstract to pod, and various other changes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl module Net::Bamboo
 
 0.02 2014-03-
+    - Added abstract section to pod
     - Added this Changes file
 
 0.01 2011-11-20

--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for Perl module Net::Bamboo
     - Specified min version of Perl 5.8.3
     - Added abstract section to pod
     - Added COPYRIGHT AND LICENSE section to the pod
+    - Added [GithubMeta] to dist.ini, so github repo listed in metadata
     - Added this Changes file
 
 0.01 2011-11-20

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl module Net::Bamboo
 
 0.02 2014-03-
+    - Specified min version of Perl 5.8.3
     - Added abstract section to pod
     - Added this Changes file
 

--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for Perl module Net::Bamboo
 0.02 2014-03-
     - Specified min version of Perl 5.8.3
     - Added abstract section to pod
+    - Added COPYRIGHT AND LICENSE section to the pod
     - Added this Changes file
 
 0.01 2011-11-20

--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@ Revision history for Perl module Net::Bamboo
     - Added abstract section to pod
     - Added COPYRIGHT AND LICENSE section to the pod
     - Added [GithubMeta] to dist.ini, so github repo listed in metadata
+    - Listed github repo (as a link to the repo) in the pod
     - Added this Changes file
 
 0.01 2011-11-20

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl module Net::Bamboo
 
 0.02 2014-03-
+    - Not all prereqs were listed, switched to [AutoPrereqs] in dist.ini
     - Specified min version of Perl 5.8.3
     - Added abstract section to pod
     - Added COPYRIGHT AND LICENSE section to the pod

--- a/Changes
+++ b/Changes
@@ -1,0 +1,8 @@
+Revision history for Perl module Net::Bamboo
+
+0.02 2014-03-
+    - Added this Changes file
+
+0.01 2011-11-20
+    - First release to CPAN
+

--- a/dist.ini
+++ b/dist.ini
@@ -13,6 +13,8 @@ copyright_holder	= Mike Eldridge
 [EOLTests]
 [CompileTests]
 
+[GithubMeta]
+
 [Prereqs]
 DateTimeX::Easy		= 0.089
 IO::File			= 0.14

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name				= Net-Bamboo
-version				= 0.01
+version				= 0.02
 author				= Mike Eldridge <diz@cpan.org>
 license				= Perl_5
 copyright_holder	= Mike Eldridge

--- a/dist.ini
+++ b/dist.ini
@@ -15,10 +15,4 @@ copyright_holder	= Mike Eldridge
 
 [GithubMeta]
 
-[Prereqs]
-DateTimeX::Easy		= 0.089
-IO::File			= 0.14
-Moose				= 2.00
-MooseX::Types::URI	= 0.02
-XML::Tidy			= 1.12
-XML::XPath			= 1.13
+[AutoPrereqs]

--- a/lib/Net/Bamboo.pm
+++ b/lib/Net/Bamboo.pm
@@ -139,6 +139,10 @@ sub refresh
 
 __END__
 
+=head1 NAME
+
+Net::Bamboo - interface for the REST services provided by Atlassian Bamboo
+
 =head1 SYNOPSIS
 
  use Net::Bamboo;

--- a/lib/Net/Bamboo.pm
+++ b/lib/Net/Bamboo.pm
@@ -222,7 +222,14 @@ are more than welcome.
 
 =head1 AUTHOR
 
-Mike Eldridge <diz@cpan.org>
+Mike Eldridge E<lt>diz@cpan.orgE<gt>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2011 by Mike Eldridge E<lt>diz@cpan.orgE<gt>
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
 
 =cut
 

--- a/lib/Net/Bamboo.pm
+++ b/lib/Net/Bamboo.pm
@@ -220,6 +220,10 @@ it's likely to be used much less often.
 This is a rough first cut.  Pull requests against my github repository
 are more than welcome.
 
+=head1 REPOSITORY
+
+L<https://github.com/tripside/net-bamboo>
+
 =head1 AUTHOR
 
 Mike Eldridge E<lt>diz@cpan.orgE<gt>

--- a/lib/Net/Bamboo.pm
+++ b/lib/Net/Bamboo.pm
@@ -2,6 +2,7 @@ package Net::Bamboo;
 
 # ABSTRACT: OO Interface for the REST services provided by Atlassian Bamboo
 
+use 5.008003;
 use Moose;
 use MooseX::Types::URI qw(Uri FileUri DataUri);
 


### PR DESCRIPTION
Hi,

I started off wanting to add an abstract to your pod (so your module would appear in the usual way in MetaCPAN), but have also done some other things, which are listed in the Changes file (which I added :-)

This should now get the module `CPANTS clean' according to [your dashboard](http://cpants.cpanauthors.org/author/diz) (ignoring is_prereq).

Cheers,
Neil
